### PR TITLE
Fixed the link to the proper CC0 license page

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ All scripts, datasets, and documentation are [permissively and openly licensed](
 
 * All **media components** (text, figures, etc.) are licensed under the [Attribution International (CC BY) 4.0 License](https://creativecommons.org/licenses/by/4.0/)
 * All **code** is licensed under the permissive open source [MIT License](https://opensource.org/licenses/MIT)
-* All **datasets** are licensed under the [Creative Commons CC0 License](https://creativecommons.org/share-your-work/public-domain/cc0/)
+* All **datasets** are licensed under the [Creative Commons CC0 License](https://creativecommons.org/publicdomain/zero/1.0/)
 
 ## Datasets
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ All scripts, datasets, and documentation are [permissively and openly licensed](
 
 * All **media components** (text, figures, etc.) are licensed under the [Attribution International (CC BY) 4.0 License](https://creativecommons.org/licenses/by/4.0/)
 * All **code** is licensed under the permissive open source [MIT License](https://opensource.org/licenses/MIT)
-* All **datasets** are licensed under the [Creative Commons CC0 License](https://creativecommons.org/publicdomain/zero/1.0/)
+* All **datasets** are licensed under the [Creative Commons CC0 1.0 License](https://creativecommons.org/publicdomain/zero/1.0/)
 
 ## Datasets
 


### PR DESCRIPTION
The original link was a page about the license, not the actual license.
Also the very first link to ``license.md`` leads to a file that's not there. I'm not sure what that file should contain, just letting you know.